### PR TITLE
Replace wp_parse_args with array_merge

### DIFF
--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -340,7 +340,7 @@ class LudicrousDB extends wpdb {
 		);
 
 		// Merge using defaults
-		$db      = wp_parse_args( $db, $database_defaults );
+		$db      = array_merge( $db, $database_defaults );
 
 		// Break these apart to make code easier to understand below
 		$dataset = $db['dataset'];

--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -340,7 +340,7 @@ class LudicrousDB extends wpdb {
 		);
 
 		// Merge using defaults
-		$db      = array_merge( $db, $database_defaults );
+		$db      = array_merge( $database_defaults, $db );
 
 		// Break these apart to make code easier to understand below
 		$dataset = $db['dataset'];


### PR DESCRIPTION
`wp_parse_args` is an unnecessary dependency from `wp-includes/functions.php` which limits the ways this library can be loaded. `array_merge` is a better alternative.