### PR TITLE
Check at least 1 connection attempt is made before cycling through retries

### DIFF
--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -746,7 +746,7 @@ class LudicrousDB extends wpdb {
 					: null;
 
 				// Connect if necessary or possible
-				if ( ! empty( $use_master ) || empty( $tries_remaining ) || ( true === $tcp ) ) {
+				if ( ! empty( $use_master ) || empty( $tries_remaining ) || ( true === $tcp ) || ! isset( $this->last_connection ) ) {
 					$this->single_db_connect( $dbhname, $host_and_port, $user, $password );
 				} else {
 					$this->dbhs[ $dbhname ] = false;


### PR DESCRIPTION
When not using the Check TCP Connectivity feature (switched off in https://github.com/humanmade/hm-platform/pull/141 for Altis) the logic to add the server details multiple times for retries results in showing the failed to connect output multiple times before actually trying the connection.

This update checks that if no connection attempts have been made yet to try one before moving on to cycling through available servers until the last one.

This resolves the issue with error logs being filled up with rows like the following:

```
[02-Feb-2022 23:31:27 UTC] WordPress database error 2022-02-02 23:31:27 Can't select global__r - 
```