### PR TITLE
Correct the documented `dbh` property type

### DIFF
--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -44,7 +44,7 @@ class LudicrousDB extends wpdb {
 	/**
 	 * The current MySQL link resource
 	 *
-	 * @var resource
+	 * @var mysqli|resource|false|null
 	 */
 	public $dbh;
 


### PR DESCRIPTION
See https://core.trac.wordpress.org/changeset/52373

The `dbh` property is an instance of `mysqli` most of the time