### PR TITLE
Improve PHP 8 1 compatibility

### DIFF
--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -1640,7 +1640,7 @@ class LudicrousDB extends wpdb {
 
 				if ( $this->dbh_type_check( $dbh ) ) {
 					if ( true === $this->use_mysqli ) {
-						$client_version = mysqli_get_client_info( $dbh );
+						$client_version = mysqli_get_client_info();
 					} else {
 						$client_version = mysql_get_client_info( $dbh );
 					}


### PR DESCRIPTION
Related Issue : https://github.com/humanmade/product-dev/issues/1198

```
PHP Deprecated:  mysqli_get_client_info(): Passing connection object as an argument is deprecated in /usr/src/app/vendor/humanmade/ludicrousdb/ludicrousdb/includes/class-ludicrousdb.php on line 1643
```

> To avoid the deprecation notice on all PHP versions, call the mysqli_get_client_info function without any parameters.

This issue resolves the deprecated notice based on the above solution.