### PR TITLE
PHP 8.1: MySQLi: Default error mode set to exceptions

### DIFF
--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -1518,7 +1518,11 @@ class LudicrousDB extends wpdb {
 		}
 
 		if ( true === $this->use_mysqli ) {
-			$result = mysqli_query( $dbh, $query );
+			try {
+				$result = mysqli_query( $dbh, $query );
+			} catch ( \mysqli_sql_exception $e ) {
+				return false;
+			}
 		} else {
 			$result = mysql_query( $query, $dbh );
 		}


### PR DESCRIPTION
In PHP 8.1, the default error handling behavior of the MySQLi extension has changed from silencing errors to throw an Exception on errors.

https://php.watch/versions/8.1/mysqli-error-mode