### PR TITLE
Force MYSQLI_REPORT_OFF for PHP 8.1+ compatibility

### DIFF
--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -463,6 +463,11 @@ class LudicrousDB extends wpdb {
 	 */
 	public function db_connect( $query = '' ) {
 
+		// PHP 8.1+ compat, see: https://core.trac.wordpress.org/changeset/51582
+		if ( $this->use_mysqli ) {
+			mysqli_report( MYSQLI_REPORT_OFF );
+		}
+
 		// Bail if empty query
 		if ( empty( $query ) ) {
 			return false;


### PR DESCRIPTION
The PHP 8.1+ defaults throw exceptions when an errors occur. This behavior is undesired for WordPress, the "Add Site" functionality in particular, which explicitly queries a database table that doesn't exist.

See: https://core.trac.wordpress.org/changeset/51582
Fixes: #6