### PR TITLE
Do not attempt to reuse last_found_rows_result

### DIFF
--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -1384,8 +1384,9 @@ class LudicrousDB extends wpdb {
 				)
 			)
 		) {
-			$this->result = $this->last_found_rows_result;
-			$elapsed      = 0;
+			$this->result                 = $this->last_found_rows_result;
+			$this->last_found_rows_result = null;
+			$elapsed                      = 0;
 		} else {
 			$this->dbh = $this->db_connect( $query );
 


### PR DESCRIPTION
A second `FOUND_ROWS()` query results in a fatal error because the `mysqli_result` object stored in `$this->result` and `$this->last_found_rows_result` is the same object after a successful first call to `FOUND_ROWS()`, which on the next query is freed by `$this->flush()`.

The error is:

```
PHP Fatal error:  Uncaught Error: mysqli_result object is already closed in /path/to/ludicrousdb/includes/class-ludicrousdb.php:1077
```

To reproduce:

```
add_action( 'plugins_loaded', function() {
    global $wpdb;
    $wpdb->query( "SELECT SQL_CALC_FOUND_ROWS * FROM wp_posts LIMIT 1");
    $wpdb->query( "SELECT FOUND_ROWS()" );
    $wpdb->query( "SELECT FOUND_ROWS()" );
    die();
} );
```

This change ensures that a `$last_found_rows_result` is used only once and we do not attempt to use a `mysqli_result` that has been freed.