### PR TITLE
Correct the return type docs for the `query()` method

### DIFF
--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -1285,7 +1285,8 @@ class LudicrousDB extends wpdb {
 	 *
 	 * @param string $query Query.
 	 *
-	 * @return int number of rows
+	 * @return int|bool Boolean true for CREATE, ALTER, TRUNCATE and DROP queries. Number of rows
+	 *                  affected/selected for all other queries. Boolean false on error.
 	 */
 	public function query( $query ) {
 


### PR DESCRIPTION
The `query()` method is documented incorrectly. This updates the docs to match those in WordPress core.