### PR TITLE
Replace deprecated ping functions

### DIFF
--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -1206,11 +1206,11 @@ class LudicrousDB extends wpdb {
 
 		if ( $this->dbh_type_check( $dbh ) ) {
 			if ( true === $this->use_mysqli ) {
-				if ( mysqli_ping( $dbh ) ) {
+				if ( mysqli_query( $dbh, 'DO 1' ) !== false ) {
 					return true;
 				}
 			} else {
-				if ( mysql_ping( $dbh ) ) {
+				if ( mysql_query( 'DO 1', $dbh ) !== false ) {
 					return true;
 				}
 			}


### PR DESCRIPTION
Replace mysqli_ping() and mysql_ping() with equivalent queries to check database connection status using modern approaches.

This removes the deprecation notices in PHP 8.4