### PR TITLE
Allow composer/installers v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   },
   "require": {
     "php": ">=5.2",
-    "composer/installers": "~1.0"
+    "composer/installers": "~1.0 || ^2.0"
   },
   "require-dev": {
     "wp-coding-standards/wpcs": "^2.2",


### PR DESCRIPTION
## Summary

- The current constraint `~1.0` pins consumers to `composer/installers` 1.x, which is unmaintained and triggers PHP 8.4 implicit-nullable deprecation notices on every composer command (`Implicitly marking parameter \$filesystem as nullable is deprecated`).
- v2 fixes these by using explicit nullable types (`?Filesystem`, `?BinaryInstaller`).
- Widening to `~1.0 || ^2.0` lets consumers on PHP 8.4+ resolve to v2; v1 remains valid for older setups.

This is the same widening already used by sibling humanmade plugins (e.g. asset-loader, aws-ses-wp-mail, batcache, cavalcade, hm-redirects, s3-uploads).

## Test plan
- [ ] In a PHP 8.4 project consuming `humanmade/ludicrousdb`, run `composer update composer/installers` — verify v2.x resolves and the deprecation notices stop.
- [ ] Verify the plugin still installs to `content/mu-plugins/ludicrousdb/` (or wherever the consumer's `installer-paths` directs) under v2.